### PR TITLE
Only lint CSS files with prettier

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,4 @@
 {
-  "src/**/*.{js,html}": ["prettier --check", "eslint"]
+  "src/**/*.{js,html}": ["prettier --check", "eslint"],
+  "src/**/*.css": ["prettier --check"],
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "src/**/*.{js,html,css}": ["prettier --check", "eslint"]
+  "src/**/*.{js,html}": ["prettier --check", "eslint"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",
         "@commitlint/config-conventional": "^19.7.1",
+        "eslint-plugin-css-modules": "^2.12.0",
         "husky": "^8.0.0",
         "lint-staged": "^15.4.3",
         "prettier": "^3.5.0"
@@ -7935,6 +7936,23 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-css-modules": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.12.0.tgz",
+      "integrity": "sha512-ruFBdad69ABrbCDCh5mXj7UzNmrvytfzPACjyvZWIAjFZAG8BXpYSbqmE8gU5wF+pIzV3jU2CWhLvfekXT/IgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "lodash": "^4.17.2"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=2.0.0"
+      }
+    },
     "node_modules/eslint-plugin-flowtype": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
@@ -9398,6 +9416,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "gonzales": "bin/gonzales.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/gopd": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",
     "@commitlint/config-conventional": "^19.7.1",
+    "eslint-plugin-css-modules": "^2.12.0",
     "husky": "^8.0.0",
     "lint-staged": "^15.4.3",
     "prettier": "^3.5.0"


### PR DESCRIPTION
# Overview

This PR fixes the linting configuration to correctly only lint CSS files with prettier (styling) instead of eslint (syntax/structure).
