### PR TITLE
Add routing to the site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
+        "react-router-dom": "^7.2.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^4.2.4"
       },
@@ -3869,6 +3870,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -15216,6 +15223,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.2.0.tgz",
+      "integrity": "sha512-fXyqzPgCPZbqhrk7k3hPcCpYIlQ2ugIXDboHUzhJISFVy2DEPsmHgN588MyGmkIOv3jDgNfUE3kJi83L28s/LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.2.0.tgz",
+      "integrity": "sha512-cU7lTxETGtQRQbafJubvZKHEn5izNABxZhBY0Jlzdv0gqQhCPQt2J8aN5ZPjS6mQOXn5NnirWNh+FpE8TTYN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -16073,6 +16129,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -17517,6 +17579,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.2.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^4.2.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,21 @@
-import React, { useState } from "react";
+import React from "react";
 import Gameplay from "pages/gameplay/Gameplay";
+import { Routes, Route } from "react-router-dom";
 
 function App() {
-  return <Gameplay />;
+  return (
+    <Routes>
+      <Route path="" element={<h1>Introduction</h1>} />
+      <Route path="/game/tutorial" element={<h1>Tutorial</h1>} />
+      <Route path="/game/calendar" element={<Gameplay />} />
+      <Route path="/game/end-of-day" element={<h1>End of day</h1>} />
+      <Route path="/game/end-of-week" element={<h1>End of week</h1>} />
+      <Route
+        path="*"
+        element={<h1>Make sure this redirects to introduction</h1>}
+      />
+    </Routes>
+  );
 }
 
 export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { BrowserRouter as Router } from "react-router-dom";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </React.StrictMode>,
 );


### PR DESCRIPTION
# Overview

This PR adds routing functionality to the app. Currently, there is just header text for the pages that aren't implemented yet.

The current routes are:

"" - Introduction page
"/game/tutorial" - Tutorial page
"/game/calendar" - Gameplay
"/game/end-of-day" - End of day page
"/game/end-of-week" - End of week page
"\*" - Introduction page (though it's linked to the "" path whatsoever)

## Notes

When we create the "Introduction" page/component, we have to make sure that same page is used for when we match the wildcard (\*) route.
